### PR TITLE
Fix Apollon Converter not working because Apollon state cannot be retrieved

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,10 @@
 ARG build_dir=/build_application
 
 # first stage which builds the application
-FROM node:14
+FROM node:18
 
 ARG build_dir
-ENV DEPLOYMENT_URL="http://localhost:8080"
+ENV DEPLOYMENT_URL="http://localhost:8081"
 
 # make build dir
 WORKDIR $build_dir
@@ -17,12 +17,12 @@ RUN yarn install
 RUN yarn build
 
 # second stage which creates the container image to run the application
-FROM node:14
+FROM node:18
 
-EXPOSE 8080
+EXPOSE 8081
 
-RUN useradd -r -s /bin/false apollon_converter \
-    && mkdir /opt/apollon_converter \
+RUN useradd -r -s /bin/false apollon_converter
+RUN mkdir /opt/apollon_converter
 
 RUN chown -R apollon_converter /opt/apollon_converter
 

--- a/src/main/controllers/controller.ts
+++ b/src/main/controllers/controller.ts
@@ -11,8 +11,9 @@ const controllers = {
       if (typeof model === 'string') {
         model = JSON.parse(model);
       }
+      const artemisDiagram: boolean = req.body.artemisDiagram;
       const service: ConversionService = new ConversionService();
-      const { svg, clip } = await service.convertToSvg((model as unknown) as UMLModel);
+      const { svg, clip } = await service.convertToSvg((model as unknown) as UMLModel, artemisDiagram);
       const { width, height } = clip;
       pdfMake.vfs = pdfFonts.pdfMake.vfs;
       const doc = pdfMake.createPdf({

--- a/src/main/services/convertToPdf.ts
+++ b/src/main/services/convertToPdf.ts
@@ -6,9 +6,10 @@ export class ConversionService {
    * Gets an uml model of apollon and returns svg of it
    *
    * @param model
+   * @param artemisDiagram whether the model is a diagram created on artemis or not
    * @returns an svg object with svg string and bounds
    */
-  convertToSvg = async (model: UMLModel): Promise<SVG> => {
+  convertToSvg = async (model: UMLModel, artemisDiagram?: boolean): Promise<SVG> => {
     document.body.innerHTML = '<!doctype html><html lang="en"><body><div></div></body></html>';
 
     // JSDOM does not support getBBox so we have to mock it here
@@ -20,6 +21,6 @@ export class ConversionService {
       height: 10,
     });
 
-    return ApollonEditor.exportModelAsSvg(model,{});
+    return ApollonEditor.exportModelAsSvg(model,{artemisDiagram});
   };
 }

--- a/src/main/services/convertToPdf.ts
+++ b/src/main/services/convertToPdf.ts
@@ -20,9 +20,6 @@ export class ConversionService {
       height: 10,
     });
 
-    const container = document.querySelector('div')!;
-    const editor = new ApollonEditor(container, {});
-    editor.model = model;
-    return editor.exportAsSVG();
+    return ApollonEditor.exportModelAsSvg(model,{});
   };
 }


### PR DESCRIPTION
This PR fixes the apollon conversion service, so it works again because since upgrading apollon, it would always fail with the error: Apollon state cannot be retrieved. The editor might already have been destroyed because of an undefined redux store.
It now invokes the static method of the apollon editor instead of the instance method and then the store is properly set up.
Additionally, I updated the dockerfile to use a recent node version and to expose the correct port.
Furthermore, I introduced an additional option artemisDiagram that can be sent to the service if it's a diagram coming from Artemis because it seems they require a special handling.
